### PR TITLE
Fix reloader.moon so that it works with the latest version of linotify

### DIFF
--- a/lovekit/reloader.lua
+++ b/lovekit/reloader.lua
@@ -18,7 +18,9 @@ local dirsep, pathsep, wildcard = unpack((function()
   end
   return _accum_0
 end)())
-local handle = inotify.init(true)
+local handle = inotify.init({
+  blocking = false
+})
 local actions = { }
 local watching = { }
 local insert

--- a/lovekit/reloader.moon
+++ b/lovekit/reloader.moon
@@ -7,7 +7,7 @@ config_char = (n) -> package.config\sub n,n
 -- /, ;, ?
 dirsep, pathsep, wildcard = unpack [config_char n for n in *{1,3,5}]
 
-handle = inotify.init true
+handle = inotify.init { blocking: false }
 actions = {}
 watching = {} -- directories being watched
 
@@ -199,4 +199,3 @@ bind!
   :update, :watch, :watch_class
   :bind
 }
-


### PR DESCRIPTION
Linotify has changed it so that their init function went from this:

```lua
inotify.init(non_blocking)
```

to this:

```lua
inotify.init { blocking = false }
```

This PR updates the code so that it properly sets Linotify as non-blocking. Otherwise, the program hangs, as the game can never get past the `events = handle\read!` line in the reloader file.

(See https://github.com/hoelzro/linotify/issues/10https://github.com/hoelzro/linotify/issues/10)